### PR TITLE
Corrected positioning of slots

### DIFF
--- a/lib/myWarehouseVisualizer.js
+++ b/lib/myWarehouseVisualizer.js
@@ -357,12 +357,12 @@ function fnShowMyWarehouseVisualizerDemo(){
 				   https://stackoverflow.com/questions/49956422/what-is-difference-between-boxbuffergeometry-vs-boxgeometry-in-three-js
 				BoxBufferGeometry(width : Float, height : Float, depth : Float, widthSegments : Integer, heightSegments : Integer, depthSegments : Integer)
 
-					width — Width of the sides on the X axis. Default is 1.
-					height — Height of the sides on the Y axis. Default is 1.
-					depth — Depth of the sides on the Z axis. Default is 1.
-					widthSegments — Optional. Number of segmented faces along the width of the sides. Default is 1.
-					heightSegments — Optional. Number of segmented faces along the height of the sides. Default is 1.
-					depthSegments — Optional. Number of segmented faces along the depth of the sides. Default is 1. 
+					width Â— Width of the sides on the X axis. Default is 1.
+					height Â— Height of the sides on the Y axis. Default is 1.
+					depth Â— Depth of the sides on the Z axis. Default is 1.
+					widthSegments Â— Optional. Number of segmented faces along the width of the sides. Default is 1.
+					heightSegments Â— Optional. Number of segmented faces along the height of the sides. Default is 1.
+					depthSegments Â— Optional. Number of segmented faces along the depth of the sides. Default is 1. 
 				
 				*/		
 
@@ -416,9 +416,9 @@ function fnShowMyWarehouseVisualizerDemo(){
 
 				slot.name = layoutData[i][Object.keys(layoutData[i])[0]];		//.name is used as unique key for getObjectByName method. Eg: properties.warehouseGroup.getObjectByName("someName")
 				//Translatiing slot warehouse coordinates to WebGL screen coordinates
-				slot.position.x = layoutData[i]["X"] + (layoutData[i]["HEIGHT"] / 2)  ; 
-				slot.position.y = layoutData[i]["Z"] + (layoutData[i]["DEPTH"] / 2); 								
-				slot.position.z =  layoutData[i]["Y"] + (layoutData[i]["HEIGHT"] / 2);  
+				slot.position.x = layoutData[i]["X"] + (layoutData[i]["WIDTH"] / 2)  ; 
+				slot.position.y = layoutData[i]["Z"] + (layoutData[i]["HEIGHT"] / 2); 								
+				slot.position.z =  layoutData[i]["Y"] + (layoutData[i]["DEPTH"] / 2);  
 				slot.userData.aisle = layoutData[i]["AISLE"];
 				slot.userData.aisleSide = layoutData[i]["AISLESIDE"];
 				slot.userData.centerAxis = layoutData[i]["CENTERAXIS"]
@@ -1458,7 +1458,7 @@ function myDataVisualizer(){
 					properties.camera.obj.add(new THREE.AmbientLight(0xffffff,0.5));
 					
 					var directionLight = new THREE.DirectionalLight(0xffffff,0.25);
-						directionLight.position.set(0.5, 0, 0.866); // ~60Âº
+						directionLight.position.set(0.5, 0, 0.866); // ~60Ã‚Âº
 					properties.camera.obj.add(directionLight);
 				
 					


### PR DESCRIPTION
Hi, I've just tried to use your app to "recreate" my warehouse which consist of shelves of different width, heights and depths. I've written proper layout.csv file, but it occured that "upper shelves" which should be right above one another or "neighbour shelves" which should be next to each other have gaps between them or are moved among axes. I've corrected few lines of code and the problem was resolved, so I create this pull request if you would like to implemet it to master branch.
	
Thanks for the app.
Best regards,
ZAAN